### PR TITLE
Improve build.sh CLI and support multiple kernel versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,15 +26,8 @@ jobs:
       - name: Pull kernel source
         run: git submodule update --init --depth 1
 
-      - name: Build Container
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          load: true
-          tags: pandare/kernel_builder:latest
-
       - name: Build Kernel
-        run: docker run --rm -v $PWD:/app pandare/kernel_builder /app/_in_container_build.sh
+        run: ./build.sh
 
       - name: Save package
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,12 +23,5 @@ jobs:
       - name: Pull kernel source
         run: git submodule update --init --depth 1
 
-      - name: Build Container
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          load: true
-          tags: pandare/kernel_builder:latest
-
       - name: Build Kernel
-        run: docker run --rm -v $PWD:/app pandare/kernel_builder /app/_in_container_build.sh
+        run: ./build.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "linux"]
-	path = linux
+[submodule "linux_4.10"]
+	path = linux/4.10
 	url = https://github.com/panda-re/linux.git
 	branch = 4.10_min

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ git commit -a
 ```
 
 ## Linting configs
-Before commiting any config update you MUST lint your change by running `./build.sh configonly`. You can specify architectures to lint by listing them as additional arguments, e.g., `./build.sh configonly armel mipel`.
+Before commiting any config update you MUST lint your change by running `./build.sh --config-only`. You can specify architectures to lint with the `--targets` flag, e.g., `./build.sh --config-only --targets "armel mipel"`.

--- a/_in_container_build.sh
+++ b/_in_container_build.sh
@@ -2,31 +2,20 @@
 
 set -eu
 
-# We want to build linux for each of our targets using the config files. Linux is in /app/linux
+# We want to build linux for each of our targets and versions using the config files. Linux is in /app/linux/[version]
 # while our configs are at config.[arch]. We need to set the ARCH and CROSS_COMPILE variables
 # and put the binaries in /app/binaries
 
-# If our first argument is configonly we'll only update the defconfigs
-CONFIGONLY=false
-if [ $# -gt 0 ] && [ "$1" == "configonly" ]; then
-    CONFIGONLY=true
-    shift
-fi
+# Get options from build.sh
+CONFIG_ONLY="$1"
+VERSIONS="$2"
+TARGETS="$3"
 
-# Arguments are a list of architectures.
-# If none are set, we'll use our defaults
-if [ $# -eq 0 ]; then
-    TARGET_LIST="armel mipseb mipsel mips64eb"
-else
-    TARGET_LIST=$@
-fi
-
-echo "Configonly: $CONFIGONLY"
-echo "Target_list: $TARGET_LIST"
+echo "Config only: $CONFIG_ONLY"
+echo "Versions: $VERSIONS"
+echo "Targets: $TARGETS"
 
 # Set this to update defconfigs instead of building kernel
-
-mkdir -p /kernels
 
 get_cc() {
     local arch=$1
@@ -47,7 +36,8 @@ get_cc() {
     echo "/opt/cross/${arch}-linux-musl${abi}/bin/${arch}-linux-musl${abi}-"
 }
 
-for TARGET in $TARGET_LIST; do
+for VERSION in $VERSIONS; do
+for TARGET in $TARGETS; do
     BUILD_TARGETS="vmlinux"
     if [ $TARGET == "armel" ]; then
         BUILD_TARGETS="vmlinux zImage"
@@ -70,35 +60,35 @@ for TARGET in $TARGET_LIST; do
 
     # Actually build
     echo "Building kernel for $TARGET"
-    make -C /app/linux ARCH=${short_arch} CROSS_COMPILE=$(get_cc $TARGET) O=/tmp/build/${TARGET}/ olddefconfig
+    make -C /app/linux/$VERSION ARCH=${short_arch} CROSS_COMPILE=$(get_cc $TARGET) O=/tmp/build/${TARGET}/ olddefconfig
 
     # If updating configs, lint them with kernel first! This sorts, removes default options and duplicates.
-    if $CONFIGONLY; then
+    if $CONFIG_ONLY; then
       echo "Updating $TARGET config in place"
-      make -C /app/linux ARCH=${short_arch} CROSS_COMPILE=$(get_cc $TARGET) O=/tmp/build/${TARGET}/ savedefconfig
+      make -C /app/linux/$VERSION ARCH=${short_arch} CROSS_COMPILE=$(get_cc $TARGET) O=/tmp/build/${TARGET}/ savedefconfig
       cp /tmp/build/${TARGET}/defconfig /app/config.${TARGET}
       echo "Finished update for config.${TARGET}"
     else
-      make -C /app/linux ARCH=${short_arch} CROSS_COMPILE=$(get_cc $TARGET) O=/tmp/build/${TARGET}/ $BUILD_TARGETS -j$(nproc)
+      make -C /app/linux/$VERSION ARCH=${short_arch} CROSS_COMPILE=$(get_cc $TARGET) O=/tmp/build/${TARGET}/ $BUILD_TARGETS -j$(nproc)
+
+      mkdir -p /kernels/$VERSION
 
       # Copy out zImage (if present) and vmlinux (always)
       if [ -f "/tmp/build/${TARGET}/arch/${short_arch}/boot/zImage" ]; then
-          cp "/tmp/build/${TARGET}/arch/${short_arch}/boot/zImage" /kernels/zImage.${TARGET}
+          cp "/tmp/build/${TARGET}/arch/${short_arch}/boot/zImage" /kernels/$VERSION/zImage.${TARGET}
       fi
-      cp "/tmp/build/${TARGET}/vmlinux" /kernels/vmlinux.${TARGET}
+      cp "/tmp/build/${TARGET}/vmlinux" /kernels/$VERSION/vmlinux.${TARGET}
 
       # Generate OSI profile
-      echo "[${TARGET}]" >> /kernels/osi.config
+      echo "[${TARGET}]" >> /kernels/$VERSION/osi.config
       /panda/panda/plugins/osi_linux/utils/kernelinfo_gdb/run.sh \
-        /kernels/vmlinux.${TARGET} /tmp/panda_profile.${TARGET}
-      cat /tmp/panda_profile.${TARGET} >> /kernels/osi.config
-
-        #/bin/dwarf2json linux --elf /kernels/vmlinux.${TARGET} \
-        #| xz - > /kernels/vmlinux.${TARGET}.json.xz
+        /kernels/$VERSION/vmlinux.${TARGET} /tmp/panda_profile.${TARGET}
+      cat /tmp/panda_profile.${TARGET} >> /kernels/$VERSION/osi.config
     fi
 done
+done
 
-if ! $CONFIGONLY; then
+if ! $CONFIG_ONLY; then
   echo "Built by linux_builder on $(date)" > /kernels/README.txt
   tar cvfz /app/kernels-latest.tar.gz /kernels
 fi


### PR DESCRIPTION
- Move linux submodule to linux/4.10 (to make room for linux/6.7 later)
- Add `./build.sh --help` flag
- Change build.sh usage from `./build.sh configonly armel mipsel` to `./build.sh --config-only --targets "armel mipsel"`, since this makes it much easier to have defaults when there are multiple lists (targets and versions)
- Support building multiple versions through `--versions`, and put the output in a per-version directory inside `kernels-latest.tar.gz`.